### PR TITLE
feat: refactor service selection into component

### DIFF
--- a/frontend/src/components/quotes/QuoteCalculator.tsx
+++ b/frontend/src/components/quotes/QuoteCalculator.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Calculator, DollarSign } from 'lucide-react';
 import { PerthSuburbSelector } from './PerthSuburbSelector';
+import { ServiceTypeSelector, ServiceOption } from './ServiceTypeSelector';
 import suburbs from '@/data/perth-suburbs.json';
 
 interface QuoteCalculatorProps {
@@ -57,7 +58,7 @@ export const QuoteCalculator: React.FC<QuoteCalculatorProps> = ({
     onSubmit(quoteData);
   };
 
-  const services = [
+  const services: ServiceOption[] = [
     { id: 'residential', name: 'Residential Glass', basePrice: 150 },
     { id: 'commercial', name: 'Commercial Glazing', basePrice: 250 },
     { id: 'emergency', name: 'Emergency Service', basePrice: 350 },
@@ -66,20 +67,9 @@ export const QuoteCalculator: React.FC<QuoteCalculatorProps> = ({
     { id: 'windows', name: 'Window Repairs', basePrice: 160 }
   ];
 
-  const handleServiceToggle = (serviceId: string) => {
-    setSelectedServices(prev => {
-      const newServices = prev.includes(serviceId)
-        ? prev.filter(id => id !== serviceId)
-        : [...prev, serviceId];
-      
-      // Update base price
-      const newBasePrice = services
-        .filter(service => newServices.includes(service.id))
-        .reduce((sum, service) => sum + service.basePrice, 0);
-      
-      setBasePrice(newBasePrice);
-      return newServices;
-    });
+  const handleServiceChange = (servicesSelected: string[], price: number) => {
+    setSelectedServices(servicesSelected);
+    setBasePrice(price);
   };
 
   return (
@@ -110,26 +100,7 @@ export const QuoteCalculator: React.FC<QuoteCalculatorProps> = ({
         {/* Services Section */}
         <div className="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Select Services</h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {services.map(service => (
-              <div
-                key={service.id}
-                className={`p-4 rounded-lg border cursor-pointer transition-colors ${
-                  selectedServices.includes(service.id)
-                    ? 'bg-blue-50 border-blue-200'
-                    : 'bg-white border-gray-200 hover:border-blue-200'
-                }`}
-                onClick={() => handleServiceToggle(service.id)}
-              >
-                <div className="flex items-center justify-between">
-                  <span className="font-medium text-gray-900">{service.name}</span>
-                  <span className="text-sm text-gray-600">
-                    ${service.basePrice}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
+          <ServiceTypeSelector services={services} onChange={handleServiceChange} />
         </div>
 
         {/* Additional Notes */}

--- a/frontend/src/components/quotes/ServiceTypeSelector.tsx
+++ b/frontend/src/components/quotes/ServiceTypeSelector.tsx
@@ -28,6 +28,7 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  }, [services, initialSelected, onChange]);
   const toggleService = (id: string) => {
     setSelected(prev => {
       const updated = prev.includes(id)

--- a/frontend/src/components/quotes/ServiceTypeSelector.tsx
+++ b/frontend/src/components/quotes/ServiceTypeSelector.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+
+export interface ServiceOption {
+  id: string;
+  name: string;
+  basePrice: number;
+}
+
+interface ServiceTypeSelectorProps {
+  services: ServiceOption[];
+  initialSelected?: string[];
+  onChange?: (selected: string[], basePrice: number) => void;
+}
+
+export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
+  services,
+  initialSelected = [],
+  onChange
+}) => {
+  const [selected, setSelected] = useState<string[]>(initialSelected);
+
+  // Notify parent of initial state
+  useEffect(() => {
+    const initialPrice = services
+      .filter(service => initialSelected.includes(service.id))
+      .reduce((sum, service) => sum + service.basePrice, 0);
+    onChange?.(initialSelected, initialPrice);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const toggleService = (id: string) => {
+    setSelected(prev => {
+      const updated = prev.includes(id)
+        ? prev.filter(s => s !== id)
+        : [...prev, id];
+      const newPrice = services
+        .filter(service => updated.includes(service.id))
+        .reduce((sum, service) => sum + service.basePrice, 0);
+      onChange?.(updated, newPrice);
+      return updated;
+    });
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {services.map(service => (
+        <div
+          key={service.id}
+          className={`p-4 rounded-lg border cursor-pointer transition-colors ${
+            selected.includes(service.id)
+              ? 'bg-blue-50 border-blue-200'
+              : 'bg-white border-gray-200 hover:border-blue-200'
+          }`}
+          onClick={() => toggleService(service.id)}
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-medium text-gray-900">{service.name}</span>
+            <span className="text-sm text-gray-600">${service.basePrice}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+

--- a/frontend/src/components/quotes/index.ts
+++ b/frontend/src/components/quotes/index.ts
@@ -11,6 +11,7 @@ export { PerthSuburbSelector } from './PerthSuburbSelector';
 export { PricingBreakdown } from './PricingBreakdown';
 export { QuoteActions } from './QuoteActions';
 export { QuoteCalculator } from './QuoteCalculator';
+export { ServiceTypeSelector } from './ServiceTypeSelector';
 
 // Type exports
 export type { QuoteData } from './QuoteCalculator';


### PR DESCRIPTION
## Summary
- add ServiceTypeSelector for toggling services and computing base price
- integrate ServiceTypeSelector into QuoteCalculator
- export ServiceTypeSelector from quotes component index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended" to extend from)*
- `npm run type-check` *(fails: TS errors in existing ui index file)*

------
https://chatgpt.com/codex/tasks/task_e_68969e5e28fc8326a04aed182bf637d1